### PR TITLE
Create an endpoint to retrieve Pens based on a tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,13 +550,68 @@ Search Pens, Posts, Collections, and Users by keyword.
 	    {
 	      ...
 	    },
-
 	}
 
 
 *** You can pass the `page`parameter, example: `GET /search/pens/?q=canvas-club&page=2`
 
 * * *
+
+### Tags
+
+Get Pens with a tag
+
+#### Parameters
+
+*   `tag:`
+
+    The tag to retrieve, must be passed on all tag endpoints.
+
+*   `page:`
+
+    The current page, defaults to 1
+
+#### Tag Endpoints
+
+*   [/tag/svg](http://cpv2api.com/tag/svg)
+
+    Search for pens containing the keyword _svg_
+
+#### Example Response
+
+`GET /tag/canvas`
+
+	{
+	  "success": "true",
+	  "data": [
+	    {
+	      "title": "Transition",
+	      "details": "<p>This was a little js port I did from a flash project I stumbled upon when looking into learning more about flash\/js similarities. <\/p>",
+	      "link": "http:\/\/codepen.io\/tholman\/pen\/BHohK",
+	      "id": "BHohK",
+	      "views": "6020",
+	      "loves": "183",
+	      "comments": "1",
+	      "images": {
+	        "small": "http:\/\/codepen.io\/tholman\/pen\/BHohK\/image\/small.png",
+	        "large": "http:\/\/codepen.io\/tholman\/pen\/BHohK\/image\/large.png"
+	      },
+	      "user": {
+	        "nicename": "Tim Holman",
+	        "username": "tholman",
+	        "avatar": "https:\/\/s3-us-west-2.amazonaws.com\/s.cdpn.io\/277\/profile\/profile-80_5.jpg"
+	      }
+	    },
+	    {
+	      ...
+	    }
+	}
+
+
+*** You can pass the `page`parameter to paginate through results. Example: `GET /tag/canvas?page=2`
+
+* * *
+
 ## Example Usage
 
 Simple example of getting the popular pens with jQuery's `.getJSON()`

--- a/app.js
+++ b/app.js
@@ -51,7 +51,7 @@ if(cluster.isMaster){
 	  res.render("index");
 	});
 
-	app.get(['/pens/:type?/:user?', '/collection/:id', '/search/pens'], function(req, res){
+	app.get(['/pens/:type?/:user?', '/collection/:id', '/search/pens', '/tag/:tag'], function(req, res){
 
 		var query = req.query;
 		var page = query.page ? query.page : '1';
@@ -64,6 +64,8 @@ if(cluster.isMaster){
 			which = "collection";
 		} else if(req.originalUrl.indexOf("search/pens") > -1){
 			which = "search";
+		} else if(req.originalUrl.indexOf("tag") > -1){
+			which = "tag";
 		} else {
 			which = "pens";
 		}
@@ -86,6 +88,10 @@ if(cluster.isMaster){
 			var searchQuery = query.q ? query.q : "";
 			url =  siteUrl + '/search/pens/?limit='+limit+'&page='+page+'&q=' + searchQuery;
 			endpoint = '/search/pens?q=' + searchQuery + '&limit=' + limit;
+		} else if(which === "tag") {
+			var tag = req.params.tag;
+			url = siteUrl + '/tag/grid/' + tag + '?page=' + page;
+			endpoint = '/tag/' + tag + '/';
 		}
 		
 		

--- a/app.js
+++ b/app.js
@@ -7,17 +7,17 @@ if(cluster.isMaster){
 	console.log('Master cluster setting up ' + numWorkers + ' workers...');
 
 	for(var i = 0; i < numWorkers; i++) {
-	    cluster.fork();
+			cluster.fork();
 	}
 
 	cluster.on('online', function(worker) {
-	    console.log('Worker ' + worker.process.pid + ' is online');
+			console.log('Worker ' + worker.process.pid + ' is online');
 	});
 
 	cluster.on('exit', function(worker, code, signal) {
-	    console.log('Worker ' + worker.process.pid + ' died with code: ' + code + ', and signal: ' + signal);
-	    console.log('Starting a new worker');
-	    cluster.fork();
+			console.log('Worker ' + worker.process.pid + ' died with code: ' + code + ', and signal: ' + signal);
+			console.log('Starting a new worker');
+			cluster.fork();
 	});
 } else {
 
@@ -31,10 +31,10 @@ if(cluster.isMaster){
 
 	// CORS middleware
 	var allowCrossDomain = function(req, res, next) {
-	    res.header('Access-Control-Allow-Origin', '*');
-	    res.header('Access-Control-Allow-Methods', 'GET');
-	    res.header('Access-Control-Allow-Headers', 'Content-Type');
-	    next();
+			res.header('Access-Control-Allow-Origin', '*');
+			res.header('Access-Control-Allow-Methods', 'GET');
+			res.header('Access-Control-Allow-Headers', 'Content-Type');
+			next();
 	}
 
 
@@ -48,7 +48,7 @@ if(cluster.isMaster){
 
 
 	app.get('/', function(req, res) {
-	  res.render("index");
+		res.render("index");
 	});
 
 	app.get(['/pens/:type?/:user?', '/collection/:id', '/search/pens', '/tag/:tag'], function(req, res){
@@ -113,7 +113,7 @@ if(cluster.isMaster){
 				} else {
 					res.send({ error: '404 from CodePen the check that the id of the collection is correct, like /collection/AdbzyJ' });
 				}
-	   			
+					
 			}
 
 			var $ = which == "search" ?  cheerio.load(body) : cheerio.load(JSON.parse(body).page.html);
@@ -229,7 +229,7 @@ if(cluster.isMaster){
 				} else {
 					res.send({ error: '404 from CodePen (check for typos), supported endpoints for a user are posts/published/{username}, posts/popular/{username}, posts/loved/{username}' });
 				}
-			 			
+						
 			}
 
 			$ = which === "search" ? cheerio.load(body) : cheerio.load(JSON.parse(body).page.html);
@@ -603,23 +603,23 @@ if(cluster.isMaster){
 	})
 
 	app.get('*', function(req, res, next) {
-	  var err = new Error();
-	  err.status = 404;
-	  next(err);
+		var err = new Error();
+		err.status = 404;
+		next(err);
 	});
 
 	 
 	// handling 404 errors
 	app.use(function(err, req, res, next) {
-	  if(err.status !== 404) {
-	    return next();
-	  }
-	  res.render("error", { message: err.message || "Something went wrong! Please try again." } );
+		if(err.status !== 404) {
+			return next();
+		}
+		res.render("error", { message: err.message || "Something went wrong! Please try again." } );
 	});
 
 
 
 	app.listen(app.get('port'), function() {
-	  console.log('server runnin on ', app.get('port'));
+		console.log('server runnin on ', app.get('port'));
 	});
 }

--- a/views/index.jade
+++ b/views/index.jade
@@ -16,8 +16,6 @@ html
 				p An unofficial, public JSON API for 
 					a(href="http://codepen.io") CodePen
 
-
-
 				h2 API Endpoints
 				
 				h3#pens Pens
@@ -121,7 +119,6 @@ html
 						a(href="/pens/public/keithwyland?tag=tenlines") /pens/public/keithwyland?tag=tenlines
 						p Get keithwyland's pens tagged "tenlines"
 
-						
 				h3 Example Response
 				p 
 					code GET /pens/popular/tmrDevelops
@@ -332,9 +329,6 @@ html
 					code GET /collections/loved/natewiley?page=2
 				
 				hr
-
-
-
 				
 				h4 Get a collection by ID
 				
@@ -438,8 +432,6 @@ html
 						    {
 						    	...
 						    },
-
-
 
 				hr
 
@@ -602,13 +594,74 @@ html
 					    {
 					      ...
 					    },
-
 					}
 
 				p.text-center *** You can pass the  
 					code page
 					| parameter, example: 
 					code GET /search/pens/?q=canvas-club&page=2	
+
+				hr
+
+				h3#tags Tags
+
+				Get Pens with a tag
+
+				h4 Parameters
+
+				ul
+					li 
+						code q:
+						p The tag to retrieve, must be passed on all tag endpoints.
+					li 
+						code page:
+						p The current page, defaults to 1
+
+
+				h4 Tag Endpoints
+
+				ul
+					li 
+						a(href="tag/") /tag/svg
+						p Get Pens tagged
+							em SVG
+
+				h3 Example Response
+
+				code GET /tag/canvas
+
+				pre.
+
+					{
+					  "success": "true",
+					  "data": [
+					    {
+					      "title": "Transition",
+					      "details": "<p>This was a little js port I did from a flash project I stumbled upon when looking into learning more about flash\/js similarities. <\/p>",
+					      "link": "http:\/\/codepen.io\/tholman\/pen\/BHohK",
+					      "id": "BHohK",
+					      "views": "6020",
+					      "loves": "183",
+					      "comments": "1",
+					      "images": {
+					        "small": "http:\/\/codepen.io\/tholman\/pen\/BHohK\/image\/small.png",
+					        "large": "http:\/\/codepen.io\/tholman\/pen\/BHohK\/image\/large.png"
+					      },
+					      "user": {
+					        "nicename": "Tim Holman",
+					        "username": "tholman",
+					        "avatar": "https:\/\/s3-us-west-2.amazonaws.com\/s.cdpn.io\/277\/profile\/profile-80_5.jpg"
+					      }
+					    },
+					    {
+					      ...
+					    }
+					}
+
+				p.text-center *** You can pass the  
+					code page
+					| parameter, example: 
+					code GET /tag/canvas?page=2 
 
 				hr
 
@@ -624,6 +677,5 @@ html
 							// do something awesome
 						}
 					});
-
 			
-			include footer.jade						 
+			include footer.jade


### PR DESCRIPTION
This adds an endpoint that allows the retrieval of Pens via a tag, which felt like it was missing from the current API. If I'm not mistaken, CodePen's search inherently looks at tags but it's nice to have a way to look one up directly. Possible use case would be pulling related Pens which would be sorta neat.

Also, there was some minor mixed whitespace in app.js so I went ahead and fixed it.
