### PR TITLE
Fixes some small goofs

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,7 +575,7 @@ Get Pens with a tag
 
 *   [/tag/svg](http://cpv2api.com/tag/svg)
 
-    Search for pens containing the keyword _svg_
+    Get Pens tagged _svg_
 
 #### Example Response
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ An unofficial, public JSON API for [CodePen](http://codepen.io)
 				...
 			}
 
-You can pass the `page`parameter to paginate through results. Example: `GET /pens/popular?page=2`
+*** You can pass the `page`parameter to paginate through results. Example: `GET /pens/popular?page=2`
 
 * * *
 
@@ -144,7 +144,7 @@ Get Pens for a specfic user
 				...
 			},
 
-You can pass the `page`parameter to paginate through results. Example: `GET /pens/popular/tmrDevelops?page=2`
+*** You can pass the `page`parameter to paginate through results. Example: `GET /pens/popular/tmrDevelops?page=2`
 
 * * *
 
@@ -189,7 +189,7 @@ You can pass the `page`parameter to paginate through results. Example: `GET /pen
 			}
 
 
-You can pass the `page`parameter to paginate through results. Example: `GET /posts/popular?page=2`
+*** You can pass the `page`parameter to paginate through results. Example: `GET /posts/popular?page=2`
 
 * * *
 
@@ -238,7 +238,7 @@ Get Posts for a specfic user
 			},
 
 
-You can pass the `page`parameter to paginate through results. Example: `GET /posts/published/towc?page=2`
+*** You can pass the `page`parameter to paginate through results. Example: `GET /posts/published/towc?page=2`
 
 * * *
 
@@ -449,7 +449,7 @@ Get followers / following data by user.
 	    },
 
 
-You can pass the `page`parameter, example: `GET /followers/pixelass?page=2`
+*** You can pass the `page`parameter, example: `GET /followers/pixelass?page=2`
 
 * * *
 

--- a/views/index.jade
+++ b/views/index.jade
@@ -623,7 +623,7 @@ html
 				ul
 					li 
 						a(href="tag/svg") /tag/svg
-						p Get Pens tagged
+						p Get Pens tagged 
 							em SVG
 
 				h3 Example Response

--- a/views/index.jade
+++ b/views/index.jade
@@ -622,7 +622,7 @@ html
 
 				ul
 					li 
-						a(href="tag/") /tag/svg
+						a(href="tag/svg") /tag/svg
 						p Get Pens tagged
 							em SVG
 


### PR DESCRIPTION
I goofed on a couple things, this corrects 'em.
### index.jade
- Fixes example endpoint URL for tags (currently `/tag/` instead of `/tag/svg`
- Fixes spacing in description of example endpoint (I suck at jade, apparently)
### README
- Appends `***` to all pagination instructions  (for consistency, some had it and some didn't)
- Fixes tag endpoint verbiage (previously referred to searches instead)
