### PR TITLE
Reorganize Tags in the docs so they make more sense

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,49 @@ Get Posts for a specfic user
 
 ### Tags
 
+Get Pens with a tag
+
+*   [/tag/svg](http://cpv2api.com/tag/svg)
+
+    Get Pens tagged _svg_
+
+#### Example Response
+
+`GET /tag/canvas`
+
+	{
+	  "success": "true",
+	  "data": [
+	    {
+	      "title": "Transition",
+	      "details": "<p>This was a little js port I did from a flash project I stumbled upon when looking into learning more about flash\/js similarities. <\/p>",
+	      "link": "http:\/\/codepen.io\/tholman\/pen\/BHohK",
+	      "id": "BHohK",
+	      "views": "6020",
+	      "loves": "183",
+	      "comments": "1",
+	      "images": {
+	        "small": "http:\/\/codepen.io\/tholman\/pen\/BHohK\/image\/small.png",
+	        "large": "http:\/\/codepen.io\/tholman\/pen\/BHohK\/image\/large.png"
+	      },
+	      "user": {
+	        "nicename": "Tim Holman",
+	        "username": "tholman",
+	        "avatar": "https:\/\/s3-us-west-2.amazonaws.com\/s.cdpn.io\/277\/profile\/profile-80_5.jpg"
+	      }
+	    },
+	    {
+	      ...
+	    }
+	}
+
+
+*** You can pass the `page`parameter to paginate through results. Example: `GET /tag/canvas?page=2`
+
+* * *
+
+### Tags by user
+
 Get tags for a user
 
 *   [/tags/pixelass](http://cpv2api.com/tags/pixelass)
@@ -554,61 +597,6 @@ Search Pens, Posts, Collections, and Users by keyword.
 
 
 *** You can pass the `page`parameter, example: `GET /search/pens/?q=canvas-club&page=2`
-
-* * *
-
-### Tags
-
-Get Pens with a tag
-
-#### Parameters
-
-*   `tag:`
-
-    The tag to retrieve, must be passed on all tag endpoints.
-
-*   `page:`
-
-    The current page, defaults to 1
-
-#### Tag Endpoints
-
-*   [/tag/svg](http://cpv2api.com/tag/svg)
-
-    Get Pens tagged _svg_
-
-#### Example Response
-
-`GET /tag/canvas`
-
-	{
-	  "success": "true",
-	  "data": [
-	    {
-	      "title": "Transition",
-	      "details": "<p>This was a little js port I did from a flash project I stumbled upon when looking into learning more about flash\/js similarities. <\/p>",
-	      "link": "http:\/\/codepen.io\/tholman\/pen\/BHohK",
-	      "id": "BHohK",
-	      "views": "6020",
-	      "loves": "183",
-	      "comments": "1",
-	      "images": {
-	        "small": "http:\/\/codepen.io\/tholman\/pen\/BHohK\/image\/small.png",
-	        "large": "http:\/\/codepen.io\/tholman\/pen\/BHohK\/image\/large.png"
-	      },
-	      "user": {
-	        "nicename": "Tim Holman",
-	        "username": "tholman",
-	        "avatar": "https:\/\/s3-us-west-2.amazonaws.com\/s.cdpn.io\/277\/profile\/profile-80_5.jpg"
-	      }
-	    },
-	    {
-	      ...
-	    }
-	}
-
-
-*** You can pass the `page`parameter to paginate through results. Example: `GET /tag/canvas?page=2`
 
 * * *
 

--- a/views/index.jade
+++ b/views/index.jade
@@ -394,6 +394,55 @@ html
 
 				h3#tags Tags
 
+				p Get Pens with a tag
+
+				ul
+					li 
+						a(href="tag/svg") /tag/svg
+						p Get Pens tagged 
+							em SVG
+
+				h3 Example Response
+
+				code GET /tag/canvas
+
+				pre.
+
+					{
+					  "success": "true",
+					  "data": [
+					    {
+					      "title": "Transition",
+					      "details": "<p>This was a little js port I did from a flash project I stumbled upon when looking into learning more about flash\/js similarities. <\/p>",
+					      "link": "http:\/\/codepen.io\/tholman\/pen\/BHohK",
+					      "id": "BHohK",
+					      "views": "6020",
+					      "loves": "183",
+					      "comments": "1",
+					      "images": {
+					        "small": "http:\/\/codepen.io\/tholman\/pen\/BHohK\/image\/small.png",
+					        "large": "http:\/\/codepen.io\/tholman\/pen\/BHohK\/image\/large.png"
+					      },
+					      "user": {
+					        "nicename": "Tim Holman",
+					        "username": "tholman",
+					        "avatar": "https:\/\/s3-us-west-2.amazonaws.com\/s.cdpn.io\/277\/profile\/profile-80_5.jpg"
+					      }
+					    },
+					    {
+					      ...
+					    }
+					}
+
+				p.text-center *** You can pass the  
+					code page
+					| parameter, example: 
+					code GET /tag/canvas?page=2 
+
+				hr
+
+				h3#tags-by-user Tags by user
+
 				p Get tags for a user
 
 				ul
@@ -600,68 +649,6 @@ html
 					code page
 					| parameter, example: 
 					code GET /search/pens/?q=canvas-club&page=2	
-
-				hr
-
-				h3#tags Tags
-
-				Get Pens with a tag
-
-				h4 Parameters
-
-				ul
-					li 
-						code q:
-						p The tag to retrieve, must be passed on all tag endpoints.
-					li 
-						code page:
-						p The current page, defaults to 1
-
-
-				h4 Tag Endpoints
-
-				ul
-					li 
-						a(href="tag/svg") /tag/svg
-						p Get Pens tagged 
-							em SVG
-
-				h3 Example Response
-
-				code GET /tag/canvas
-
-				pre.
-
-					{
-					  "success": "true",
-					  "data": [
-					    {
-					      "title": "Transition",
-					      "details": "<p>This was a little js port I did from a flash project I stumbled upon when looking into learning more about flash\/js similarities. <\/p>",
-					      "link": "http:\/\/codepen.io\/tholman\/pen\/BHohK",
-					      "id": "BHohK",
-					      "views": "6020",
-					      "loves": "183",
-					      "comments": "1",
-					      "images": {
-					        "small": "http:\/\/codepen.io\/tholman\/pen\/BHohK\/image\/small.png",
-					        "large": "http:\/\/codepen.io\/tholman\/pen\/BHohK\/image\/large.png"
-					      },
-					      "user": {
-					        "nicename": "Tim Holman",
-					        "username": "tholman",
-					        "avatar": "https:\/\/s3-us-west-2.amazonaws.com\/s.cdpn.io\/277\/profile\/profile-80_5.jpg"
-					      }
-					    },
-					    {
-					      ...
-					    }
-					}
-
-				p.text-center *** You can pass the  
-					code page
-					| parameter, example: 
-					code GET /tag/canvas?page=2 
 
 				hr
 

--- a/views/index.jade
+++ b/views/index.jade
@@ -76,9 +76,9 @@ html
 						        "avatar": "//s3-us-west-2.amazonaws.com/s.cdpn.io/142996/profile/profile-80_5.jpg"
 						      }
 						    },
-								{
-									...
-								}
+						  {
+						    ...
+						  }
 
 				p.text-center *** You can pass the  
 					code page
@@ -124,43 +124,43 @@ html
 					code GET /pens/popular/tmrDevelops
 					pre.
 						{
-							"success": "true",
-							  "data": [
-							    {
-							      "title": "Verlet",
-							      "details": "&lt;p&gt;I was trying to recreate the verlet effect on an SVG Polygon...but it has some boundary issues I need to work out.  Drag / throw the object; use the slider to change the number of points / object shape.  &lt;/p&gt;",
-							      "link": "http://codepen.io/tmrDevelops/pen/MYVzMe",
-							      "id": "MYVzMe",
-							      "views": "22021",
-							      "loves": "217",
-							      "comments": "21",
-							      "images": {
-							          "small": "http://codepen.io/tmrDevelops/pen/MYVzMe/image/small.png",
-							          "large": "http://codepen.io/tmrDevelops/pen/MYVzMe/image/large.png"
-							      },
-							      "user": {
-							        "username": "tmrDevelops"
-							      }
-							    },
-							    {
-							      "title": "Galactic Orbitals",
-							      "details": "&lt;p&gt;Galaxy clusters orbiting galaxy clusters, orbiting galaxy clusters...After a short while of orbiting, smaller clusters travel to the centers of larger galaxies &amp;&amp; connections are formed&lt;/p&gt;",
-							      "link": "http://codepen.io/tmrDevelops/pen/PqQKzJ",
-							      "id": "PqQKzJ",
-							      "views": "19682",
-							      "loves": "155",
-							      "comments": "10",
-							      "images": {
-							          "small": "http://codepen.io/tmrDevelops/pen/PqQKzJ/image/small.png",
-							          "large": "http://codepen.io/tmrDevelops/pen/PqQKzJ/image/large.png"
-							      },
-							      "user": {
-							        "username": "tmrDevelops"
-							      }
-							    },
-								{
-									...
-								},
+						  "success": "true",
+						    "data": [
+						      {
+						        "title": "Verlet",
+						        "details": "&lt;p&gt;I was trying to recreate the verlet effect on an SVG Polygon...but it has some boundary issues I need to work out.  Drag / throw the object; use the slider to change the number of points / object shape.  &lt;/p&gt;",
+						        "link": "http://codepen.io/tmrDevelops/pen/MYVzMe",
+						        "id": "MYVzMe",
+						        "views": "22021",
+						        "loves": "217",
+						        "comments": "21",
+						        "images": {
+						            "small": "http://codepen.io/tmrDevelops/pen/MYVzMe/image/small.png",
+						            "large": "http://codepen.io/tmrDevelops/pen/MYVzMe/image/large.png"
+						        },
+						        "user": {
+						          "username": "tmrDevelops"
+						        }
+						      },
+						      {
+						        "title": "Galactic Orbitals",
+						        "details": "&lt;p&gt;Galaxy clusters orbiting galaxy clusters, orbiting galaxy clusters...After a short while of orbiting, smaller clusters travel to the centers of larger galaxies &amp;&amp; connections are formed&lt;/p&gt;",
+						        "link": "http://codepen.io/tmrDevelops/pen/PqQKzJ",
+						        "id": "PqQKzJ",
+						        "views": "19682",
+						        "loves": "155",
+						        "comments": "10",
+						        "images": {
+						            "small": "http://codepen.io/tmrDevelops/pen/PqQKzJ/image/small.png",
+						            "large": "http://codepen.io/tmrDevelops/pen/PqQKzJ/image/large.png"
+						        },
+						        "user": {
+						          "username": "tmrDevelops"
+						        }
+						      },
+						    {
+						      ...
+						    },
 
 				p.text-center *** You can pass the  
 					code page
@@ -347,7 +347,7 @@ html
 						  "data": [
 						    {
 						      "title": "Codevember Day 10",
-						      "details": "<p>Ele love &lt;3</p>",
+						      "details": "&lt;p&gt;Ele love &lt;3&lt;/p&gt;",
 						      "link": "http://codepen.io/maicodes/pen/KdrmjL",
 						      "id": "KdrmjL",
 						      "views": "461",
@@ -365,7 +365,7 @@ html
 						    },
 						    {
 						      "title": "Codevember Day 9",
-						      "details": "<p>&lt;3 my pen pals\nExperimenting with  <a href=\"http://codepen.io/natewiley/\">Nate Wiley</a>&apos;s new API. </p>",
+						      "details": "&lt;p&gt;&lt;3 my pen pals\nExperimenting with  <a href=\"http://codepen.io/natewiley/\">Nate Wiley</a>&apos;s new API. &lt;/p&gt;",
 						      "link": "http://codepen.io/maicodes/pen/EVOYWY",
 						      "id": "EVOYWY",
 						      "views": "156",
@@ -413,20 +413,20 @@ html
 					  "data": [
 					    {
 					      "title": "Transition",
-					      "details": "<p>This was a little js port I did from a flash project I stumbled upon when looking into learning more about flash\/js similarities. <\/p>",
-					      "link": "http:\/\/codepen.io\/tholman\/pen\/BHohK",
+					      "details": "&lt;p&gt;This was a little js port I did from a flash project I stumbled upon when looking into learning more about flash/js similarities. &lt;/p&gt;",
+					      "link": "http://codepen.io\/tholman\/pen\/BHohK",
 					      "id": "BHohK",
 					      "views": "6020",
 					      "loves": "183",
 					      "comments": "1",
 					      "images": {
-					        "small": "http:\/\/codepen.io\/tholman\/pen\/BHohK\/image\/small.png",
-					        "large": "http:\/\/codepen.io\/tholman\/pen\/BHohK\/image\/large.png"
+					        "small": "http://codepen.io/tholman/pen/BHohK/image/small.png",
+					        "large": "http://codepen.io/tholman/pen/BHohK/image/large.png"
 					      },
 					      "user": {
 					        "nicename": "Tim Holman",
 					        "username": "tholman",
-					        "avatar": "https:\/\/s3-us-west-2.amazonaws.com\/s.cdpn.io\/277\/profile\/profile-80_5.jpg"
+					        "avatar": "https://s3-us-west-2.amazonaws.com/s.cdpn.io/277/profile/profile-80_5.jpg"
 					      }
 					    },
 					    {
@@ -549,22 +549,22 @@ html
 				pre.
 					
 					{
-						"success": "true",
-						"data": {
-							"nicename": "Jack Rugile",
-							"username": "jackrugile",
-							"avatar": "//s3-us-west-2.amazonaws.com/s.cdpn.io/836/profile/profile-512_4.jpg",
-							"location": "Denver, CO",
-							"bio": "",
-							"pro": true,
-							"followers": "849",
-							"following": "178",
-							"links": [
-								"https://github.com/jackrugile",
-								"http://jackrugile.com",
-								"http://twitter.com/jackrugile"
-							]
-						}
+					  "success": "true",
+					  "data": {
+					    "nicename": "Jack Rugile",
+					    "username": "jackrugile",
+					    "avatar": "//s3-us-west-2.amazonaws.com/s.cdpn.io/836/profile/profile-512_4.jpg",
+					    "location": "Denver, CO",
+					    "bio": "",
+					    "pro": true,
+					    "followers": "849",
+					    "following": "178",
+					    "links": [
+					      "https://github.com/jackrugile",
+					      "http://jackrugile.com",
+					      "http://twitter.com/jackrugile"
+					    ]
+					  }
 					}
 
 				hr
@@ -659,10 +659,10 @@ html
 
 				pre.
 					$.getJSON("http://cpv2api.com/pens/popular", function(resp){
-						if(resp.success){
-							console.log(resp.data);
-							// do something awesome
-						}
+					  if(resp.success){
+					    console.log(resp.data);
+					    // do something awesome
+					  }
 					});
 			
 			include footer.jade


### PR DESCRIPTION
Last PR of the day I promise 😉 

This reorders the docs so that `Tags` (moved up) and `Tags by User` (renamed) are next to each other which I think makes a lot of sense. Also, there was a duplicate ID issue (#tags) which this fixes.

I also went ahead and simplified the Tags docs a little bit to be more in line with everything else. Previously they were based on the search endpoint docs which are (necessarily) a bit more verbose.

Also, a lot of the JSON response examples had some indentation problems caused by tabs. Personally I'd recommend swapping that entire document (`index.jade`) over to spaces to avoid future issues. You can also just swap to tabs everywhere and use `tab-size` CSS rules to control spacing, [but that doesn't work at all in IE](http://caniuse.com/#search=tab-size).

Lastly, some of the responses didn't escape paragraph tags so I fixed that where I noticed it. The same issue is also present with links, but since that doesn't cause _structural_ problems (paragraphs were breakin' stuff) it's less of a concern. I'd be happy to go through and fix those too, if you'd like.
