### PR TITLE
Fix issue with tags caused by improper URL matching

### DIFF
--- a/app.js
+++ b/app.js
@@ -59,12 +59,11 @@ if(cluster.isMaster){
 		var tag = query.tag ? query.tag : false;
 		var url, which, type;
 
-
-		if(req.originalUrl.indexOf("collection") > -1){
+		if(req.originalUrl.match(/^\/collection/)){
 			which = "collection";
-		} else if(req.originalUrl.indexOf("search/pens") > -1){
+		} else if(req.originalUrl.match(/^\/search\/pens/)){
 			which = "search";
-		} else if(req.originalUrl.indexOf("tag") > -1){
+		} else if(req.originalUrl.match(/^\/tag/)){
 			which = "tag";
 		} else {
 			which = "pens";


### PR DESCRIPTION
So if I'm not mistaken I broke this when I added the `tag/` endpoint since `indexOf` is looking at the entire URL string.

I think realistically we should be using RegEx instead of `indexOf` for pretty much all URL matching to avoid future regressions, but this should fix #6 for now. I'd recommend reviewing before accepting the PR 'cause my RegEx chops are weak :-)
